### PR TITLE
Add `notificationcmd` account option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ server = "imap.gmail.com"
 port = 993
 username = "jon@gmail.com"
 pwcmd = "gnome-keyring-query get gmail_pw"
+notificationcmd = "ssh -t somehost wall 'New gmail message!'" #Optional
 ```
 
 ## Account fields
@@ -45,6 +46,7 @@ arrive for an account. The options for an account are as follows:
  - `port`: The port to connect to.
  - `username`: Username for authentication.
  - `pwcmd`: Command to execute to get password for authentication.
+ - `notificationcmd`: Additional command to be executed on new messages for this account.
 
 # TODOs
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,15 +154,20 @@ impl<T: Read + Write + imap::extensions::idle::SetReadTimeout> Connection<T> {
                 if let Some(notificationcmd) = &self.account.notification_command {
                     match Command::new("sh").arg("-c").arg(notificationcmd).status() {
                         Ok(s) if s.success() => {}
-                        Ok(_) => {
-                            eprintln!(
-                                "Notification command did not exit successfully for {}",
+                        Ok(s) => {
+                            eprint!(
+                                "Notification command for {} did not exit successfully.",
                                 self.account.name
                             );
+                            if let Some(exit_code) = s.code() {
+                                eprintln!(" Exit code: {}", exit_code);
+                            } else {
+                                eprintln!(" Process was terminated by a signal.",);
+                            }
                         }
                         Err(e) => {
                             eprintln!(
-                                "Failed to notification command for {}: {}",
+                                "Could not execute notification command for {}: {}",
                                 self.account.name, e
                             );
                         }


### PR DESCRIPTION
If specified, the command is executed in addition to the standard
desktop notification when new mail arrives on this account. This is
useful for delegating notifications to other devices or triggering sync
actions using, for example, mbsync or offlineimap.