### PR TITLE
Handle possible parse failures in config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -311,7 +311,7 @@ fn main() {
                         notification_command: t.get("notificationcmd").and_then(
                             |raw_v| match raw_v.as_str() {
                                 Some(v) => Some(v.to_string()),
-                                None => parse_failed("notificationcmd", "string"),
+                                None => return parse_failed("notificationcmd", "string"),
                             },
                         ),
                     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,14 +284,38 @@ fn main() {
                     Some(Account {
                         name: name.as_str().to_owned(),
                         server: (
-                            t["server"].as_str().unwrap().to_owned(),
-                            t["port"].as_integer().unwrap() as u16,
+                            match t["server"].as_str() {
+                                Some(v) => v.to_owned(),
+                                None => {
+                                    println!("Failed to parse 'server' as string.");
+                                    return None;
+                                }
+                            },
+                            match t["port"].as_integer() {
+                                Some(v) => v as u16,
+                                None => {
+                                    println!("Failed to parse 'port' as integer.");
+                                    return None;
+                                }
+                            },
                         ),
-                        username: t["username"].as_str().unwrap().to_owned(),
+                        username: match t["username"].as_str() {
+                            Some(v) => v.to_owned(),
+                            None => {
+                                println!("Failed to parse 'username' as string.");
+                                return None;
+                            }
+                        },
                         password,
-                        notification_command: t
-                            .get("notificationcmd")
-                            .map(|v| v.as_str().unwrap().to_string()),
+                        notification_command: t.get("notificationcmd").and_then(
+                            |raw_v| match raw_v.as_str() {
+                                Some(v) => Some(v.to_string()),
+                                None => {
+                                    println!("Failed to parse 'notificationcmd' as string.");
+                                    None
+                                }
+                            },
+                        ),
                     })
                 }
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,12 @@ impl<T: Read + Write + imap::extensions::idle::SetReadTimeout> Connection<T> {
     }
 }
 
+#[inline]
+fn parse_failed<T>(key: &str, typename: &str) -> Option<T> {
+    println!("Failed to parse '{}' as {}", key, typename);
+    None
+}
+
 fn main() {
     // Load the user's config
     let xdg = match xdg::BaseDirectories::new() {
@@ -286,34 +292,26 @@ fn main() {
                         server: (
                             match t["server"].as_str() {
                                 Some(v) => v.to_owned(),
-                                None => {
-                                    println!("Failed to parse 'server' as string.");
-                                    return None;
-                                }
+                                None => return parse_failed("server", "string"),
                             },
                             match t["port"].as_integer() {
                                 Some(v) => v as u16,
                                 None => {
-                                    println!("Failed to parse 'port' as integer.");
-                                    return None;
+                                    return parse_failed("port", "integer");
                                 }
                             },
                         ),
                         username: match t["username"].as_str() {
                             Some(v) => v.to_owned(),
                             None => {
-                                println!("Failed to parse 'username' as string.");
-                                return None;
+                                return parse_failed("username", "string");
                             }
                         },
                         password,
                         notification_command: t.get("notificationcmd").and_then(
                             |raw_v| match raw_v.as_str() {
                                 Some(v) => Some(v.to_string()),
-                                None => {
-                                    println!("Failed to parse 'notificationcmd' as string.");
-                                    None
-                                }
+                                None => parse_failed("notificationcmd", "string"),
                             },
                         ),
                     })


### PR DESCRIPTION
Closes #12.

This PR uses `match` instead of `unwrap` to handle possible failures in type conversions for the values in the configuration.

In its current state, it continues on failure, meaning that if the first section is has incorrect types, subsequent sections may still work.
