### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: Continuous Integration
+
+on: push
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        rust: [stable]
+    steps:
+      # Linux dependencies
+      - name: Install dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev libpango1.0-dev libatk1.0-dev libgtk-3-dev libappindicator3-dev
+
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-features
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        rust: [stable]
+        rust: [beta, stable]
     steps:
       # Linux dependencies
       - name: Install dependencies
@@ -33,6 +33,21 @@ jobs:
         with:
           command: check
           args: --all-features
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
Related to #1, #2

I've created a CI pipeline that checks compilation on all the platforms, and rustfmt as well. Currently it only fails the check if rustfmt fails, because both macOS and Windows are failing anyway.

But it gives us a good idea of where we are platform wise, and it does let you know if the Linux build fails.

**Optional Todos**:
- [ ] Instead of failing the action if rustfmt checks do not pass, we could have the action automatically fix the formatting errors
- [ ] Add more than just stable rust to the feature matrix, could e.g. include nightly and older versions as a lower bound.
- [ ] Separate macOS/Windows jobs from linux job, failing the check if the linux fails but keeping macOS/Windows optional

Feel free to add any thoughts / improvements as well!

Edit: Example at https://github.com/LiHRaM/buzz/actions/runs/158353787