### PR TITLE
Make tray icon optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
         with:
           command: check
           args: --all-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features
 
   clippy:
     name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,13 @@ maintenance = { status = "passively-maintained" }
 [profile.release]
 debug=true
 
+[features]
+default = ["systray"]
+
 [dependencies]
 imap = "2.0"
 native-tls = "0.2"
-systray = "0.4"
+systray = { version = "0.4", optional = true }
 mailparse = "0.13"
 toml = "0.5"
 notify-rust = "4.0.0-beta.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ use std::time::Duration;
 
 use directories_next::ProjectDirs;
 
+mod tray_icon;
+
 #[derive(Clone)]
 struct Account {
     name: String,
@@ -230,6 +232,13 @@ fn parse_failed<T>(key: &str, typename: &str) -> Option<T> {
     None
 }
 
+pub enum Icon {
+    Connected,
+    Disconnected,
+    UnreadMail,
+    NewMail,
+}
+
 fn main() {
     // Load the user's config
     let config = ProjectDirs::from("", "", "buzz")
@@ -328,28 +337,14 @@ fn main() {
         return;
     }
 
-    // Create a new application
-    let mut app = match systray::Application::new() {
-        Ok(app) => app,
-        Err(e) => {
-            println!("Could not create gtk application: {}", e);
+    let (tx, rx) = mpsc::channel();
+
+    let tray_icon = match tray_icon::TrayIcon::new(tx.clone()) {
+        Ok(tray_icon) => tray_icon,
+        Err(()) => {
             return;
         }
     };
-    if let Err(e) = app.set_icon_from_file("/usr/share/icons/Faenza/stock/24/stock_disconnect.png")
-    {
-        println!("Could not set application icon: {}", e);
-    }
-
-    let (tx, rx) = mpsc::channel();
-    let tx_close = std::sync::Mutex::new(tx.clone());
-    if let Err(e) = app.add_menu_item("Quit", move |window| {
-        tx_close.lock().unwrap().send(None).unwrap();
-        window.quit();
-        Ok::<_, systray::Error>(())
-    }) {
-        println!("Could not add application Quit menu option: {}", e);
-    }
 
     // TODO: w.set_tooltip(&"Whatever".to_string());
     // TODO: app.wait_for_message();
@@ -387,8 +382,7 @@ fn main() {
     }
 
     // We have now connected
-    app.set_icon_from_file("/usr/share/icons/Faenza/stock/24/stock_connect.png")
-        .ok();
+    tray_icon.set_icon(Icon::Connected);
 
     let mut new: Vec<_> = accounts.iter().map(|_| 0).collect();
     for (i, conn) in accounts.into_iter().enumerate() {
@@ -406,11 +400,9 @@ fn main() {
         };
         new[i] = num_new;
         if new.iter().sum::<usize>() == 0 {
-            app.set_icon_from_file("/usr/share/icons/oxygen/base/32x32/status/mail-unread.png")
-                .unwrap();
+            tray_icon.set_icon(Icon::UnreadMail);
         } else {
-            app.set_icon_from_file("/usr/share/icons/oxygen/base/32x32/status/mail-unread-new.png")
-                .unwrap();
+            tray_icon.set_icon(Icon::NewMail);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,19 +18,6 @@ use directories_next::ProjectDirs;
 #[cfg(feature = "systray")]
 mod tray_icon;
 
-#[cfg(not(feature = "systray"))]
-mod tray_icon {
-    pub struct TrayIcon;
-
-    impl TrayIcon {
-        pub fn new(_tx: std::sync::mpsc::Sender<Option<(usize, usize)>>) -> Result<Self, ()> {
-            Ok(Self {})
-        }
-
-        pub fn set_icon(&self, _icon: super::Icon) {}
-    }
-}
-
 #[derive(Clone)]
 struct Account {
     name: String,
@@ -346,6 +333,7 @@ fn main() {
 
     let (tx, rx) = mpsc::channel();
 
+    #[cfg(feature = "systray")]
     let tray_icon = match tray_icon::TrayIcon::new(tx.clone()) {
         Ok(tray_icon) => tray_icon,
         Err(()) => {
@@ -389,6 +377,7 @@ fn main() {
     }
 
     // We have now connected
+    #[cfg(feature = "systray")]
     tray_icon.set_icon(tray_icon::Icon::Connected);
 
     let mut new: Vec<_> = accounts.iter().map(|_| 0).collect();
@@ -406,6 +395,8 @@ fn main() {
             break;
         };
         new[i] = num_new;
+
+        #[cfg(feature = "systray")]
         if new.iter().sum::<usize>() == 0 {
             tray_icon.set_icon(tray_icon::Icon::UnreadMail);
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,13 +246,6 @@ fn parse_failed<T>(key: &str, typename: &str) -> Option<T> {
     None
 }
 
-pub enum Icon {
-    Connected,
-    Disconnected,
-    UnreadMail,
-    NewMail,
-}
-
 fn main() {
     // Load the user's config
     let config = ProjectDirs::from("", "", "buzz")
@@ -396,7 +389,7 @@ fn main() {
     }
 
     // We have now connected
-    tray_icon.set_icon(Icon::Connected);
+    tray_icon.set_icon(tray_icon::Icon::Connected);
 
     let mut new: Vec<_> = accounts.iter().map(|_| 0).collect();
     for (i, conn) in accounts.into_iter().enumerate() {
@@ -414,9 +407,9 @@ fn main() {
         };
         new[i] = num_new;
         if new.iter().sum::<usize>() == 0 {
-            tray_icon.set_icon(Icon::UnreadMail);
+            tray_icon.set_icon(tray_icon::Icon::UnreadMail);
         } else {
-            tray_icon.set_icon(Icon::NewMail);
+            tray_icon.set_icon(tray_icon::Icon::NewMail);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,21 @@ use std::time::Duration;
 
 use directories_next::ProjectDirs;
 
+#[cfg(feature = "systray")]
 mod tray_icon;
+
+#[cfg(not(feature = "systray"))]
+mod tray_icon {
+    pub struct TrayIcon;
+
+    impl TrayIcon {
+        pub fn new(_tx: std::sync::mpsc::Sender<Option<(usize, usize)>>) -> Result<Self, ()> {
+            Ok(Self {})
+        }
+
+        pub fn set_icon(&self, _icon: super::Icon) {}
+    }
+}
 
 #[derive(Clone)]
 struct Account {

--- a/src/tray_icon.rs
+++ b/src/tray_icon.rs
@@ -1,17 +1,22 @@
 use std::sync::mpsc;
 
-use crate::Icon;
+pub(crate) enum Icon {
+    Connected,
+    Disconnected,
+    UnreadMail,
+    NewMail,
+}
 
-pub struct TrayIcon {
+pub(crate) struct TrayIcon {
     app: systray::Application,
 }
 
 impl TrayIcon {
-    pub fn new(tx: mpsc::Sender<Option<(usize, usize)>>) -> Result<Self, ()> {
+    pub(crate) fn new(tx: mpsc::Sender<Option<(usize, usize)>>) -> Result<Self, ()> {
         let mut icon = match systray::Application::new() {
             Ok(app) => Ok(Self { app }),
             Err(e) => {
-                println!("Could not create gtk application: {}", e);
+                eprintln!("Could not create gtk application: {}", e);
                 Err(())
             }
         }?;
@@ -23,13 +28,13 @@ impl TrayIcon {
             window.quit();
             Ok::<_, systray::Error>(())
         }) {
-            println!("Could not add application Quit menu option: {}", e);
+            eprintln!("Could not add application Quit menu option: {}", e);
         }
 
         Ok(icon)
     }
 
-    pub fn set_icon(&self, icon: Icon) {
+    pub(crate) fn set_icon(&self, icon: Icon) {
         let file = match icon {
             Icon::Connected => "/usr/share/icons/Faenza/stock/24/stock_connect.png",
             Icon::Disconnected => "/usr/share/icons/Faenza/stock/24/stock_disconnect.png",
@@ -37,7 +42,7 @@ impl TrayIcon {
             Icon::NewMail => "/usr/share/icons/oxygen/base/32x32/status/mail-unread-new.png",
         };
         if let Err(e) = self.app.set_icon_from_file(file) {
-            println!("Could not set application icon: {}", e);
+            eprintln!("Could not set application icon: {}", e);
         }
     }
 }

--- a/src/tray_icon.rs
+++ b/src/tray_icon.rs
@@ -1,0 +1,43 @@
+use std::sync::mpsc;
+
+use crate::Icon;
+
+pub struct TrayIcon {
+    app: systray::Application,
+}
+
+impl TrayIcon {
+    pub fn new(tx: mpsc::Sender<Option<(usize, usize)>>) -> Result<Self, ()> {
+        let mut icon = match systray::Application::new() {
+            Ok(app) => Ok(Self { app }),
+            Err(e) => {
+                println!("Could not create gtk application: {}", e);
+                Err(())
+            }
+        }?;
+        icon.set_icon(Icon::Disconnected);
+
+        let tx = std::sync::Mutex::new(tx);
+        if let Err(e) = icon.app.add_menu_item("Quit", move |window| {
+            tx.lock().unwrap().send(None).unwrap();
+            window.quit();
+            Ok::<_, systray::Error>(())
+        }) {
+            println!("Could not add application Quit menu option: {}", e);
+        }
+
+        Ok(icon)
+    }
+
+    pub fn set_icon(&self, icon: Icon) {
+        let file = match icon {
+            Icon::Connected => "/usr/share/icons/Faenza/stock/24/stock_connect.png",
+            Icon::Disconnected => "/usr/share/icons/Faenza/stock/24/stock_disconnect.png",
+            Icon::UnreadMail => "/usr/share/icons/oxygen/base/32x32/status/mail-unread.png",
+            Icon::NewMail => "/usr/share/icons/oxygen/base/32x32/status/mail-unread-new.png",
+        };
+        if let Err(e) = self.app.set_icon_from_file(file) {
+            println!("Could not set application icon: {}", e);
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the tray icon logic into a new module and makes it and the `systray` dependency optional.  It introduces the `systray` feature that is enabled by default.

Fixes #21.