### PR TITLE
Restructure config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -326,6 +326,7 @@ dependencies = [
  "mailparse",
  "notify-rust",
  "rayon",
+ "serde",
  "toml",
  "tray-item",
 ]
@@ -651,7 +652,7 @@ checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -750,7 +751,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1221,7 +1222,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1273,7 +1274,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1395,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -1413,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1665,22 +1666,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1691,7 +1692,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1773,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1831,7 +1832,7 @@ checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1916,7 +1917,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2031,7 +2032,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -2053,7 +2054,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ askama_escape = "0.10"
 chrono = "0.4"
 directories-next = "2"
 tray-item = { version = "0.9.0", features=["ksni"], optional = true}
+serde = { version = "1.0.196", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ to one account:
 
 ```toml
 [[account]]
-name = gmail
+name = "gmail"
 server = "imap.gmail.com"
 port = 993
 username = "jon@gmail.com"
-pwcmd = "gnome-keyring-query get gmail_pw"
+pwcmd = "gnome-keyring-query get gmail_pw" # or use the `password` field to set it in plain text
 notificationcmd = "ssh -t somehost wall 'New gmail message!'" #Optional
+folders = [ "INBOX" ] # Optional
 ```
 
 Additionally, icons can be configured in an icon section:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Additionally, icons can be configured in an icon section:
 ```toml
 [icons]
 connected = "/usr/share/icons/Faenza/stock/24/stock_connect.png"
-disconnect = "/usr/share/icons/Faenza/stock/24/stock_disconnect.png"
+disconnected = "/usr/share/icons/Faenza/stock/24/stock_disconnect.png"
 unread = "/usr/share/icons/oxygen/base/32x32/status/mail-unread.png"
 new_mail = "/usr/share/icons/oxygen/base/32x32/status/mail-unread-new.png"
 ```

--- a/README.md
+++ b/README.md
@@ -23,16 +23,27 @@ the same features, and is written in Go.
 buzz looks for a
 [TOML](https://github.com/toml-lang/toml#user-content-example)
 configuration file in `~/.config/buzz.toml` on startup. The
-configuration file consists of a number of sections, each corresponding
+configuration file consists of a number of account tables, each corresponding
 to one account:
 
 ```toml
-[gmail]
+[[account]]
+name = gmail
 server = "imap.gmail.com"
 port = 993
 username = "jon@gmail.com"
 pwcmd = "gnome-keyring-query get gmail_pw"
 notificationcmd = "ssh -t somehost wall 'New gmail message!'" #Optional
+```
+
+Additionally, icons can be configured in an icon section:
+
+```toml
+[icons]
+connected = "/usr/share/icons/Faenza/stock/24/stock_connect.png"
+disconnect = "/usr/share/icons/Faenza/stock/24/stock_disconnect.png"
+unread = "/usr/share/icons/oxygen/base/32x32/status/mail-unread.png"
+new_mail = "/usr/share/icons/oxygen/base/32x32/status/mail-unread-new.png"
 ```
 
 ## Account fields

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,33 +438,33 @@ fn main() {
                 connected: v
                     .get("connected")
                     .and_then(|v| {
-                        v.as_str().map(String::from).map(|s| {
-                            Box::leak(s.into_boxed_str()) as &'static str
-                        })
+                        v.as_str()
+                            .map(String::from)
+                            .map(|s| Box::leak(s.into_boxed_str()) as &'static str)
                     })
                     .unwrap_or(tray_icon::DEFAULT_ICONS.connected),
                 disconnected: v
                     .get("disconnected")
                     .and_then(|v| {
-                        v.as_str().map(String::from).map(|s| {
-                            Box::leak(s.into_boxed_str()) as &'static str
-                        })
+                        v.as_str()
+                            .map(String::from)
+                            .map(|s| Box::leak(s.into_boxed_str()) as &'static str)
                     })
                     .unwrap_or(tray_icon::DEFAULT_ICONS.connected),
                 unread: v
                     .get("unread")
                     .and_then(|v| {
-                        v.as_str().map(String::from).map(|s| {
-                            Box::leak(s.into_boxed_str()) as &'static str
-                        })
+                        v.as_str()
+                            .map(String::from)
+                            .map(|s| Box::leak(s.into_boxed_str()) as &'static str)
                     })
                     .unwrap_or(tray_icon::DEFAULT_ICONS.unread),
                 new_mail: v
                     .get("new_mail")
                     .and_then(|v| {
-                        v.as_str().map(String::from).map(|s| {
-                            Box::leak(s.into_boxed_str()) as &'static str
-                        })
+                        v.as_str()
+                            .map(String::from)
+                            .map(|s| Box::leak(s.into_boxed_str()) as &'static str)
                     })
                     .unwrap_or(tray_icon::DEFAULT_ICONS.new_mail),
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ impl ConfigAccount {
                     .context("Execute password command")?
                     .stdout,
             )
-            .context("pwcmd is not valid UTF-8")?
+            .context("pwcmd output is not valid UTF-8")?
             .trim()
             .to_string(),
             (Some(_), Some(_)) => anyhow::bail!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,14 +3,15 @@
 use anyhow::Context;
 use imap::ImapConnection;
 use rayon::prelude::*;
+use serde::Deserialize;
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::prelude::*;
+use std::path::Path;
 use std::process::Command;
 use std::sync::mpsc;
-use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -19,31 +20,113 @@ use directories_next::ProjectDirs;
 #[cfg(feature = "systray")]
 mod tray_icon;
 
-#[derive(Clone)]
-struct Account {
+#[derive(Deserialize)]
+struct Config {
+    #[cfg(feature = "systray")]
+    icons: Option<tray_icon::Icons>,
+    #[serde(rename = "account")]
+    accounts: Vec<ConfigAccount>,
+}
+
+impl Config {
+    fn from_file<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
+        let mut file = File::open(path).context("Could not open configuration file at: {path}")?;
+        let mut config_contents = String::new();
+
+        file.read_to_string(&mut config_contents)
+            .context("Could not read configuration file")?;
+
+        toml::from_str(&config_contents).context("Could not parse configuration")
+    }
+}
+
+/// A representation of an account as is available in the configuration
+#[derive(Clone, Deserialize)]
+struct ConfigAccount {
     name: String,
-    server: (String, u16),
+    server: String,
+    port: u16,
+    username: String,
+    password: Option<String>,
+    notification_command: Option<String>,
+    folder: Option<String>,
+    #[serde(default)]
+    folders: Vec<String>,
+    pwcmd: Option<String>,
+}
+
+/// A representation of an account as is used by Buzz.
+///
+/// This version of the accounts is sanitized and is duplicated into a
+/// separate account for every folder.
+#[derive(Clone, Deserialize, Debug)]
+struct ConnectionAccount {
+    name: String,
+    server: String,
+    port: u16,
     username: String,
     password: String,
     notification_command: Option<String>,
-    folders: Vec<String>,
-}
-
-#[derive(Clone)]
-struct AccountFolder {
-    account: Arc<Account>,
     folder: String,
 }
 
-impl AccountFolder {
+impl ConfigAccount {
+    fn to_connection_accounts(config: &ConfigAccount) -> anyhow::Result<Vec<ConnectionAccount>> {
+        let password = match (&config.password, &config.pwcmd) {
+            (Some(password), _) => password.clone(),
+            (None, Some(pwcmd)) => String::from_utf8_lossy(
+                Command::new("sh")
+                    .arg("-c")
+                    .arg(pwcmd)
+                    .output()
+                    .context("Password command did not produce a password")?
+                    .stdout
+                    .as_ref(),
+            )
+            .trim()
+            .to_string(),
+            (None, None) => {
+                anyhow::bail!(
+                    "Either password or pwcmd must be provided for account: {name}",
+                    name = config.name
+                )
+            }
+        };
+
+        let mut folders = config.folders.clone();
+
+        if let Some(folder) = &config.folder {
+            folders.push(folder.to_owned());
+        }
+
+        if folders.is_empty() {
+            folders.push("INBOX".to_owned());
+        }
+
+        Ok(folders
+            .into_iter()
+            .map(|folder| ConnectionAccount {
+                name: config.name.clone(),
+                server: config.server.trim().to_string(),
+                port: config.port,
+                username: config.username.trim().to_string(),
+                password: password.clone(),
+                notification_command: config.notification_command.clone(),
+                folder,
+            })
+            .collect())
+    }
+}
+
+impl ConnectionAccount {
     pub fn connect(&self) -> anyhow::Result<Connection<Box<dyn ImapConnection>>> {
-        let c = imap::ClientBuilder::new(&*self.account.server.0, self.account.server.1)
+        let c = imap::ClientBuilder::new(&*self.server, self.port)
             .mode(imap::ConnectionMode::AutoTls)
             .tls_kind(imap::TlsKind::Rust)
             .connect()
             .context("connect")?;
         let mut c = c
-            .login(self.account.username.trim(), self.account.password.trim())
+            .login(&self.username, &self.password)
             .map_err(|(e, _)| e)
             .context("login")?;
         let cap = c.capabilities().context("get capabilities")?;
@@ -61,14 +144,14 @@ impl AccountFolder {
         c.select(folder).context("select folder")?;
 
         Ok(Connection {
-            account_folder: self.clone(),
+            account: self.clone(),
             socket: c,
         })
     }
 }
 
 struct Connection<T: Read + Write> {
-    account_folder: AccountFolder,
+    account: ConnectionAccount,
     socket: imap::Session<T>,
 }
 
@@ -78,10 +161,7 @@ impl<T: Read + Write + imap::extensions::idle::SetReadTimeout> Connection<T> {
             if let Err(e) = self.check(account, &mut tx) {
                 // the connection has failed for some reason
                 // try to log out (we probably can't)
-                eprintln!(
-                    "connection to {} failed: {:?}",
-                    self.account_folder.account.name, e
-                );
+                eprintln!("connection to {} failed: {:?}", self.account.name, e);
                 let _ = self.socket.logout();
                 break;
             }
@@ -92,21 +172,15 @@ impl<T: Read + Write + imap::extensions::idle::SetReadTimeout> Connection<T> {
         for _ in 0..5 {
             eprintln!(
                 "connection to {} lost; trying to reconnect...",
-                self.account_folder.account.name
+                &self.account.name
             );
-            match self.account_folder.connect() {
+            match self.account.connect() {
                 Ok(c) => {
-                    println!(
-                        "{} connection reestablished",
-                        self.account_folder.account.name
-                    );
+                    eprintln!("{} connection reestablished", self.account.name);
                     return c.handle(account, tx);
                 }
                 Err(e) => {
-                    eprintln!(
-                        "failed to connect to {}: {:?}",
-                        self.account_folder.account.name, e
-                    );
+                    eprintln!("failed to connect to {}: {:?}", self.account.name, e);
                     thread::sleep(Duration::from_secs(wait));
                 }
             }
@@ -179,13 +253,13 @@ impl<T: Read + Write + imap::extensions::idle::SetReadTimeout> Connection<T> {
             }
 
             if !subjects.is_empty() {
-                if let Some(notificationcmd) = &self.account_folder.account.notification_command {
+                if let Some(notificationcmd) = &self.account.notification_command {
                     match Command::new("sh").arg("-c").arg(notificationcmd).status() {
                         Ok(s) if s.success() => {}
                         Ok(s) => {
                             eprint!(
                                 "Notification command for {} did not exit successfully.",
-                                self.account_folder.account.name
+                                self.account.name
                             );
                             if let Some(exit_code) = s.code() {
                                 eprintln!(" Exit code: {}", exit_code);
@@ -196,17 +270,14 @@ impl<T: Read + Write + imap::extensions::idle::SetReadTimeout> Connection<T> {
                         Err(e) => {
                             eprintln!(
                                 "Could not execute notification command for {}: {}",
-                                self.account_folder.account.name, e
+                                self.account.name, e
                             );
                         }
                     }
                 }
 
                 use notify_rust::{Hint, Notification};
-                let title = format!(
-                    "@{} has new mail ({})",
-                    self.account_folder.account.name, num_new
-                );
+                let title = format!("@{} has new mail ({})", self.account.name, num_new);
 
                 // we want the n newest e-mail in reverse chronological order
                 let mut body = String::new();
@@ -256,234 +327,42 @@ impl<T: Read + Write + imap::extensions::idle::SetReadTimeout> Connection<T> {
     }
 }
 
-#[inline]
-fn parse_failed<T>(key: &str, typename: &str) -> Option<T> {
-    println!("Failed to parse '{}' as {}", key, typename);
-    None
-}
-
-fn main() {
+fn main() -> anyhow::Result<()> {
     // Load the user's config
-    let config = ProjectDirs::from("", "", "buzz")
-        .expect("Could not find valid home directory.")
-        .config_dir()
-        .with_file_name("buzz.toml");
+    let config = Config::from_file(
+        ProjectDirs::from("", "", "buzz")
+            .expect("Could not find valid home directory.")
+            .config_dir()
+            .with_file_name("buzz.toml"),
+    )?;
 
-    let config = {
-        let mut f = match File::open(config) {
-            Ok(f) => f,
-            Err(e) => {
-                println!("Could not open configuration file buzz.toml: {}", e);
-                return;
-            }
-        };
-        let mut s = String::new();
-        if let Err(e) = f.read_to_string(&mut s) {
-            println!("Could not read configuration file buzz.toml: {}", e);
-            return;
-        }
-        match s.parse::<toml::Value>() {
-            Ok(t) => t,
-            Err(e) => {
-                println!("Could not parse configuration file buzz.toml: {}", e);
-                return;
-            }
-        }
-    };
-
-    let accounts: Vec<_> = match config.get("account") {
-        None => {
-            println!("No accounts configured");
-            return;
-        }
-        Some(toml::Value::Array(account)) => {
-            account
-                .iter()
-                .enumerate()
-                .filter_map(|(i, v)| {
-                    match v.as_table() {
-                        None => {
-                            println!("Account configuration broken. It is not a table");
-                            return None;
-                        }
-                        Some(t) => {
-                            let name = match t.get("name") {
-                                Some(toml::Value::String(name)) => name,
-                                Some(_) => {
-                                    println!("Account #{} name is not a string", i);
-                                    return None;
-                                }
-                                None => {
-                                    println!("Account #{} has no name", i);
-                                    return None;
-                                }
-                            };
-                            let pwcmd = match t.get("pwcmd").and_then(|p| p.as_str()) {
-                                None => return None,
-                                Some(pwcmd) => pwcmd,
-                            };
-
-                            let password = match Command::new("sh").arg("-c").arg(pwcmd).output() {
-                                Ok(output) => String::from_utf8_lossy(&output.stdout).into_owned(),
-                                Err(e) => {
-                                    println!(
-                                        "Failed to launch password command for {}: {}",
-                                        name, e
-                                    );
-                                    return None;
-                                }
-                            };
-
-                            Some(Account {
-                                name: name.as_str().to_owned(),
-                                server: (
-                                    match t["server"].as_str() {
-                                        Some(v) => v.to_owned(),
-                                        None => return parse_failed("server", "string"),
-                                    },
-                                    match t["port"].as_integer() {
-                                        Some(v) => v as u16,
-                                        None => {
-                                            return parse_failed("port", "integer");
-                                        }
-                                    },
-                                ),
-                                username: match t["username"].as_str() {
-                                    Some(v) => v.to_owned(),
-                                    None => {
-                                        return parse_failed("username", "string");
-                                    }
-                                },
-                                password,
-                                notification_command: t.get("notificationcmd").and_then(|raw_v| {
-                                    match raw_v.as_str() {
-                                        Some(v) => Some(v.to_string()),
-                                        None => parse_failed("notificationcmd", "string"),
-                                    }
-                                }),
-                                folders: {
-                                    // Parse the folders field
-                                    let mut folders: Vec<String> = t
-                                        .get("folders")
-                                        .and_then(|raw_v| {
-                                            raw_v
-                                                .as_array()
-                                                .map(|v| {
-                                                    v.iter()
-                                                        .filter_map(|raw_v| {
-                                                            raw_v
-                                                                .as_str()
-                                                                .map(|v| v.to_string())
-                                                                .or_else(|| {
-                                                                    parse_failed("folders", "str")
-                                                                })
-                                                        })
-                                                        .collect()
-                                                })
-                                                .or_else(|| parse_failed("folders", "array"))
-                                        })
-                                        .unwrap_or_default();
-
-                                    // Parse the old folder field and push it to the list of folders
-                                    if let Some(folder) = t.get("folder").and_then(|raw_v| {
-                                        raw_v
-                                            .as_str()
-                                            .map(|x| x.to_string())
-                                            .or_else(|| parse_failed("folder", "string"))
-                                    }) {
-                                        folders.push(folder);
-                                    }
-
-                                    if folders.is_empty() {
-                                        vec![String::from("INBOX")]
-                                    } else {
-                                        folders
-                                    }
-                                },
-                            })
-                        }
-                    }
-                })
-                .collect()
-        }
-        Some(_) => {
-            println!("Accounts should be an array of tables: [[account]]");
-            return;
-        }
-    };
-
-    if accounts.is_empty() {
-        println!("No accounts in config; exiting...");
-        return;
+    if config.accounts.is_empty() {
+        anyhow::bail!("No accounts in config; exiting...");
     }
 
-    let mut account_folders = Vec::new();
+    let (account_folders, problems): (Vec<_>, Vec<_>) = config
+        .accounts
+        .iter()
+        .map(ConfigAccount::to_connection_accounts)
+        .partition(Result::is_ok);
 
-    for account in accounts {
-        let account_ref = Arc::new(account);
-        for folder in &account_ref.folders {
-            account_folders.push(AccountFolder {
-                account: Arc::clone(&account_ref),
-                folder: folder.clone(),
-            });
-        }
+    if !problems.is_empty() {
+        eprintln!("Encountered some problems parsing the accounts:");
+    }
+    for problem in problems {
+        eprintln!("{}", problem.unwrap_err());
     }
 
     let (tx, rx) = mpsc::channel();
 
     #[cfg(feature = "systray")]
-    let mut tray_icon = {
-        let icons: tray_icon::Icons = match config.get("icons") {
-            Some(toml::Value::Table(v)) => tray_icon::Icons {
-                connected: v
-                    .get("connected")
-                    .and_then(|v| {
-                        v.as_str()
-                            .map(String::from)
-                            .map(|s| Box::leak(s.into_boxed_str()) as &'static str)
-                    })
-                    .unwrap_or(tray_icon::DEFAULT_ICONS.connected),
-                disconnected: v
-                    .get("disconnected")
-                    .and_then(|v| {
-                        v.as_str()
-                            .map(String::from)
-                            .map(|s| Box::leak(s.into_boxed_str()) as &'static str)
-                    })
-                    .unwrap_or(tray_icon::DEFAULT_ICONS.connected),
-                unread: v
-                    .get("unread")
-                    .and_then(|v| {
-                        v.as_str()
-                            .map(String::from)
-                            .map(|s| Box::leak(s.into_boxed_str()) as &'static str)
-                    })
-                    .unwrap_or(tray_icon::DEFAULT_ICONS.unread),
-                new_mail: v
-                    .get("new_mail")
-                    .and_then(|v| {
-                        v.as_str()
-                            .map(String::from)
-                            .map(|s| Box::leak(s.into_boxed_str()) as &'static str)
-                    })
-                    .unwrap_or(tray_icon::DEFAULT_ICONS.new_mail),
-            },
-            _ => tray_icon::DEFAULT_ICONS,
-        };
+    let mut tray_icon = tray_icon::TrayIcon::new(config.icons, tray_icon::Icon::Disconnected)
+        .context("Could not create tray item")?;
 
-        match tray_icon::TrayIcon::new(icons) {
-            Ok(tray_icon) => tray_icon,
-            Err(e) => {
-                eprintln!("Could not create tray item\n{}", e);
-                return;
-            }
-        }
-    };
-    // TODO: w.set_tooltip(&"Whatever".to_string());
-    // TODO: app.wait_for_message();
-
-    let accounts: Vec<_> = account_folders
-        .par_iter()
+    let account_folders: Vec<_> = account_folders
+        .into_iter()
+        .flat_map(Result::unwrap)
+        .par_bridge()
         .filter_map(|account_folder| {
             let mut wait = 1;
             for _ in 0..5 {
@@ -495,7 +374,7 @@ fn main() {
                         {
                             println!(
                                 "Failed to connect account {}: {}; retrying in {}s",
-                                account_folder.account.name, e, wait
+                                &account_folder.name, e, wait
                             );
                             thread::sleep(Duration::from_secs(wait));
                             wait *= 2;
@@ -503,7 +382,7 @@ fn main() {
                         }
                         println!(
                             "{} host produced bad IMAP tunnel: {:?}",
-                            account_folder.account.name, e
+                            account_folder.name, e
                         );
                         break;
                     }
@@ -514,19 +393,18 @@ fn main() {
         })
         .collect();
 
-    if accounts.is_empty() {
-        println!("No accounts in config worked; exiting...");
-        return;
+    if account_folders.is_empty() {
+        anyhow::bail!("No accounts in config worked; exiting...");
     }
 
     // We have now connected
     #[cfg(feature = "systray")]
-    if let Err(e) = tray_icon.set_icon(tray_icon::Icon::Connected) {
-        eprintln!("Unable to set tray icon\n{}", e);
-    };
+    tray_icon
+        .set_icon(tray_icon::Icon::Connected)
+        .context("Unable to set tray icon")?;
 
-    let mut new: Vec<_> = accounts.iter().map(|_| 0).collect();
-    for (i, conn) in accounts.into_iter().enumerate() {
+    let mut new: Vec<_> = account_folders.iter().map(|_| 0).collect();
+    for (i, conn) in account_folders.into_iter().enumerate() {
         let tx = tx.clone();
         thread::spawn(move || {
             conn.handle(i, tx);
@@ -553,4 +431,6 @@ fn main() {
             }
         }
     }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,6 @@ struct ConfigAccount {
     password: Option<String>,
     #[serde(alias = "notificationcmd")]
     notification_command: Option<String>,
-    folder: Option<String>,
     #[serde(default)]
     folders: Vec<String>,
     pwcmd: Option<String>,
@@ -94,10 +93,6 @@ impl ConfigAccount {
         };
 
         let mut folders = self.folders.clone();
-
-        if let Some(folder) = &self.folder {
-            folders.push(folder.to_owned());
-        }
 
         if folders.is_empty() {
             folders.push("INBOX".to_owned());

--- a/src/main.rs
+++ b/src/main.rs
@@ -439,8 +439,7 @@ fn main() {
                     .get("connected")
                     .and_then(|v| {
                         v.as_str().map(String::from).map(|s| {
-                            let x: &'static str = Box::leak(s.into_boxed_str());
-                            x
+                            Box::leak(s.into_boxed_str()) as &'static str
                         })
                     })
                     .unwrap_or(tray_icon::DEFAULT_ICONS.connected),
@@ -448,8 +447,7 @@ fn main() {
                     .get("disconnected")
                     .and_then(|v| {
                         v.as_str().map(String::from).map(|s| {
-                            let x: &'static str = Box::leak(s.into_boxed_str());
-                            x
+                            Box::leak(s.into_boxed_str()) as &'static str
                         })
                     })
                     .unwrap_or(tray_icon::DEFAULT_ICONS.connected),
@@ -457,8 +455,7 @@ fn main() {
                     .get("unread")
                     .and_then(|v| {
                         v.as_str().map(String::from).map(|s| {
-                            let x: &'static str = Box::leak(s.into_boxed_str());
-                            x
+                            Box::leak(s.into_boxed_str()) as &'static str
                         })
                     })
                     .unwrap_or(tray_icon::DEFAULT_ICONS.unread),
@@ -466,8 +463,7 @@ fn main() {
                     .get("new_mail")
                     .and_then(|v| {
                         v.as_str().map(String::from).map(|s| {
-                            let x: &'static str = Box::leak(s.into_boxed_str());
-                            x
+                            Box::leak(s.into_boxed_str()) as &'static str
                         })
                     })
                     .unwrap_or(tray_icon::DEFAULT_ICONS.new_mail),

--- a/src/tray_icon.rs
+++ b/src/tray_icon.rs
@@ -12,7 +12,7 @@ pub(crate) struct TrayIcon {
     app: tray_item::TrayItem,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub(crate) struct Icons {
     pub(crate) connected: String,
     pub(crate) disconnected: String,
@@ -29,8 +29,10 @@ impl Icons {
             Icon::NewMail => &self.new_mail,
         }
     }
+}
 
-    fn get_default() -> Self {
+impl Default for Icons {
+    fn default() -> Self {
         Self {
             connected: String::from("/usr/share/icons/Faenza/stock/24/stock_connect.png"),
             disconnected: String::from("/usr/share/icons/Faenza/stock/24/stock_disconnect.png"),
@@ -42,7 +44,7 @@ impl Icons {
 
 impl TrayIcon {
     pub(crate) fn new(icons: Option<Icons>, initial_icon: Icon) -> anyhow::Result<Self> {
-        let icons = icons.unwrap_or_else(Icons::get_default);
+        let icons = icons.unwrap_or_default();
         let leaked_icons: &'static Icons = Box::leak(Box::new(icons.clone())) as &'static Icons;
         let tray = tray_item::TrayItem::new(
             "Buzz",

--- a/src/tray_icon.rs
+++ b/src/tray_icon.rs
@@ -6,30 +6,48 @@ pub(crate) enum Icon {
 }
 
 pub(crate) struct TrayIcon {
+    icons: Icons,
     app: tray_item::TrayItem,
 }
 
-impl TrayIcon {
-    pub(crate) fn new(default_icon: Icon) -> anyhow::Result<Self> {
-        let icon = get_icon(default_icon);
-        let tray = tray_item::TrayItem::new("Buzz", tray_item::IconSource::Resource(icon))?;
+pub(crate) struct Icons {
+    pub(crate) connected: &'static str,
+    pub(crate) disconnected: &'static str,
+    pub(crate) unread: &'static str,
+    pub(crate) new_mail: &'static str,
+}
 
-        Ok(TrayIcon { app: tray })
-    }
-
-    pub(crate) fn set_icon(&mut self, icon: Icon) -> anyhow::Result<()> {
-        self.app
-            .set_icon(tray_item::IconSource::Resource(get_icon(icon)))?;
-
-        Ok(())
+impl Icons {
+    fn get_icon(&self, icon: Icon) -> &'static str {
+        match icon {
+            Icon::Connected => self.connected,
+            Icon::Disconnected => self.disconnected,
+            Icon::UnreadMail => self.unread,
+            Icon::NewMail => self.new_mail,
+        }
     }
 }
 
-pub(crate) fn get_icon(icon: Icon) -> &'static str {
-    match icon {
-        Icon::Connected => "/usr/share/icons/Faenza/stock/24/stock_connect.png",
-        Icon::Disconnected => "/usr/share/icons/Faenza/stock/24/stock_disconnect.png",
-        Icon::UnreadMail => "/usr/share/icons/oxygen/base/32x32/status/mail-unread.png",
-        Icon::NewMail => "/usr/share/icons/oxygen/base/32x32/status/mail-unread-new.png",
+pub(crate) const DEFAULT_ICONS: Icons = Icons {
+    connected: "/usr/share/icons/Faenza/stock/24/stock_connect.png",
+    disconnected: "/usr/share/icons/Faenza/stock/24/stock_disconnect.png",
+    unread: "/usr/share/icons/oxygen/base/32x32/status/mail-unread.png",
+    new_mail: "/usr/share/icons/oxygen/base/32x32/status/mail-unread-new.png",
+};
+
+impl TrayIcon {
+    pub(crate) fn new(icons: Icons) -> anyhow::Result<Self> {
+        let tray =
+            tray_item::TrayItem::new("Buzz", tray_item::IconSource::Resource(icons.disconnected))?;
+
+        Ok(TrayIcon { app: tray, icons })
+    }
+
+    pub(crate) fn set_icon(&mut self, icon: Icon) -> anyhow::Result<()> {
+        let icon_loc = self.icons.get_icon(icon);
+        self.app
+            .set_icon(tray_item::IconSource::Resource(icon_loc))?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
As promised, a restructured version of the config as mentioned in: [#6](https://github.com/jonhoo/buzz/issues/6#issuecomment-478699885).

I tried to keep fairly consistent with the current code structure and not refactor too much. 
However, I think it might not be the worst idea to refactor at least the configuration parsing, as this is becoming quite unwieldy.

This however will probably suffice for the major version bump. If you like to see any changes or if you have some tips, let me know, those are always welcome.